### PR TITLE
Refactor Parser Class

### DIFF
--- a/src/main/java/duke/exceptions/MissingArgumentsExceptionTodo.java
+++ b/src/main/java/duke/exceptions/MissingArgumentsExceptionTodo.java
@@ -8,8 +8,6 @@ public class MissingArgumentsExceptionTodo extends MissingArgumentsException {
 
     /**
      * Constructs a MissingArgumentsExceptionTodo with the specified detail message.
-     *
-     * @param message The detail message.
      */
     public MissingArgumentsExceptionTodo(String string) {
         super(string);

--- a/src/main/java/duke/exceptions/WrongTimeFormatException.java
+++ b/src/main/java/duke/exceptions/WrongTimeFormatException.java
@@ -23,7 +23,9 @@ public class WrongTimeFormatException extends Exception {
      */
     @Override
     public String getMessage() {
-        return "    " + super.getMessage() + "\n    Try again using the format {day month year} using "
-                + "\n    space, dash or slash as delimiters";
+        return "    " + super.getMessage()
+                + "\n    Try again using the format"
+                + "\n     {day/month/year HHmm}"
+                + "\n    or {date + H:mm pm/am}";
     }
 }

--- a/src/main/java/duke/storage/Deadlines.java
+++ b/src/main/java/duke/storage/Deadlines.java
@@ -1,11 +1,5 @@
 package duke.storage;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.Optional;
-
 /**
  * The Deadlines class represents a deadline task in the Duke task manager, which is a subtype of the Task class.
  * It inherits properties and methods from the Task class and provides a specific implementation for deadline tasks
@@ -13,8 +7,8 @@ import java.util.Optional;
  */
 public class Deadlines extends Task {
 
-    protected LocalDate by;
-    protected LocalTime byTime;
+    protected String byDate = "";
+    protected String byTime = "";
 
     /**
      * Constructs a Deadlines object with the specified original command, description, and date-time details.
@@ -25,27 +19,17 @@ public class Deadlines extends Task {
      */
     public Deadlines(String originalCommand, String description, String dateTimeBy) {
         super(originalCommand, description);
+
         String[] splitBy = dateTimeBy.split("-");
         int lenBy = splitBy.length;
+        this.byDate = splitBy[0];
 
-        if (lenBy == 3) {
-            this.by = LocalDate.parse(String.join("-", splitBy));
-        } else if (lenBy == 4) {
-            this.by = LocalDate.parse(String.join("-", Arrays.copyOfRange(splitBy,
-                    1, lenBy)));
-
-            if (splitBy[0].length() < 5 && splitBy[0].indexOf(":") != -1) {
-                splitBy[0] = "0" + splitBy[0];
+        if (lenBy > 1) {
+            if (splitBy[1] != null) {
+                this.byTime = splitBy[1];
             }
-
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("[HH:mm]" + "[HHmm]" + "[Hmm]");
-            this.byTime = LocalTime.parse(splitBy[0], formatter);
-        } else if (lenBy == 5) {
-            this.by = LocalDate.parse(String.join("-", Arrays.copyOfRange(splitBy,
-                    2, lenBy)));
-
-            this.byTime = LocalTime.parse(splitBy[1] + " " + splitBy[0], DateTimeFormatter.ofPattern("h:mm a"));
         }
+
     }
 
     /**
@@ -56,10 +40,10 @@ public class Deadlines extends Task {
      */
     @Override
     public String toString() {
-        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern(" h:mm a");
-        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("MMM dd yyyy");
-
-        return "[D]" + super.toString() + "\n (by: " + dateFormatter.format(this.by)
-                + Optional.ofNullable(byTime).map(timeFormatter::format).orElse("") + ")";
+        return "[D]" + super.toString() + "\n ( by: "
+                + this.byDate
+                + " "
+                + (this.byTime == "" ? "" : this.byTime)
+                + ")";
     }
 }

--- a/src/main/java/duke/storage/Events.java
+++ b/src/main/java/duke/storage/Events.java
@@ -1,12 +1,5 @@
 package duke.storage;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.Optional;
-
-
 /**
  * The Events class represents an event task in the Duke task manager, which is a subtype of the Task class.
  * It inherits properties and methods from the Task class and provides a specific implementation for event tasks
@@ -14,10 +7,10 @@ import java.util.Optional;
  */
 public class Events extends Task {
 
-    protected LocalDate from;
-    protected LocalTime fromTime;
-    protected LocalDate to;
-    protected LocalTime toTime;
+    protected String fromDate = "";
+    protected String fromTime = "";
+    protected String toDate = "";
+    protected String toTime = "";
 
     /**
      * Constructs an Events object with the specified original command, description, and date-time details.
@@ -32,47 +25,20 @@ public class Events extends Task {
 
         String[] splitFrom = dateTimeFrom.split("-");
         String[] splitTo = dateTimeTo.split("-");
+        this.fromDate = splitFrom[0];
+        this.toDate = splitTo[0];
 
         int lenFrom = splitFrom.length;
         int lenTo = splitTo.length;
 
-        if (lenFrom == 3) {
-            this.from = LocalDate.parse(String.join("-", splitFrom));
-        } else if (lenFrom == 4) {
-            this.from = LocalDate.parse(String.join("-", Arrays.copyOfRange(splitFrom,
-                    1, lenFrom)));
-
-            if (splitFrom[0].length() < 5 && splitTo[0].indexOf(":") != -1) {
-                splitFrom[0] = "0" + splitFrom[0];
-            }
-
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("[HH:mm]" + "[HHmm]" + "[Hmm]");
-            this.toTime = LocalTime.parse(splitFrom[0], formatter);
-        } else if (lenFrom == 5) {
-            this.from = LocalDate.parse(String.join("-", Arrays.copyOfRange(splitFrom,
-                    2, lenFrom)));
-            this.fromTime = LocalTime.parse(splitFrom[1] + " " + splitFrom[0], DateTimeFormatter.ofPattern("h:mm a"));
+        if (lenFrom > 1) {
+            this.fromTime = splitFrom[1];
+        }
+        if (lenTo > 1) {
+            this.toTime = splitTo[1];
         }
 
-        if (lenTo == 3) {
-            this.to = LocalDate.parse(String.join("-", splitTo));
-        } else if (lenTo == 4) {
-            this.to = LocalDate.parse(String.join("-", Arrays.copyOfRange(splitTo,
-                    1, lenTo)));
-
-            if (splitTo[0].length() < 5 && splitTo[0].indexOf(":") != -1) {
-                splitTo[0] = "0" + splitTo[0];
-            }
-
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("[HH:mm]" + "[HHmm]" + "[Hmm]");
-            this.toTime = LocalTime.parse(splitTo[0], formatter);
-        } else if (lenTo == 5) {
-            this.to = LocalDate.parse(String.join("-", Arrays.copyOfRange(splitTo,
-                    2, lenTo)));
-            this.toTime = LocalTime.parse(splitFrom[1] + " " + splitFrom[0], DateTimeFormatter.ofPattern("h:mm a"));
-        }
     }
-
 
     /**
      * Returns a string representation of the event task, including its specific type identifier, the result of the
@@ -82,12 +48,15 @@ public class Events extends Task {
      */
     @Override
     public String toString() {
-        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern(" h:mm a");
-        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("MMM dd yyyy");
 
-        return "[E]" + super.toString() + "\n (from: " + dateFormatter.format(this.from)
-                + Optional.ofNullable(fromTime).map(timeFormatter::format).orElse("")
-                + " to: " + dateFormatter.format(this.to)
-                + Optional.ofNullable(toTime).map(timeFormatter::format).orElse("") + ")";
+        return "[E]" + super.toString() + "\n (from: "
+                + this.fromDate
+                + " "
+                + (this.fromTime == "" ? "" : this.fromTime)
+                + " to: "
+                + this.toDate
+                + " "
+                + (this.toTime == "" ? "" : this.toTime)
+                + ")";
     }
 }

--- a/src/main/java/duke/storage/savefile.txt
+++ b/src/main/java/duke/storage/savefile.txt
@@ -1,7 +1,3 @@
-save 0 deadline hw44 /by 2 2 2044 1800
-save 0 todo hw
-save 0 todo me
-save 0 todo hw
-save 0 todo hw
-save 0 todo hw
-save 0 event fsfdsf /from 10/02/2044 /to 10/02/2045
+save 0 event hw /from 2/2/2025 /to 2/3/2025
+save 0 event hw /from 2/2/2025 1800 /to 2/3/2025 1700
+save 0 event hw /from 2/2/2025 1800 /to 2/3/2025 1700


### PR DESCRIPTION
Logic in switch statement mostly extracted out. Change handling of Datetime to entirely use LocalDateTime instead of manually parsing. Event and deadline classes now utilise a String date time, as parser converts DateTimes to String.

Fix javadocs for old methods, and add new ones for extracted methods. Fix some styling issues to follow course standard as well as coding practices. Mostly fixing guard clause.